### PR TITLE
fix: REPLY_TRANSCRIPTION not in .env.example and removed ALLOWED_USER…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ BING_TONESTYLE="precise"
 # Accepted values are "true" or "false"
 TRANSCRIPTION_ENABLED="false"
 
+# Determines whether the bot should reply with the transcribed text from your voice messages
+# Accepted values are "true" or "false"
+REPLY_TRANSCRIPTION="true"
+
 # There are 2 ways to transcribe audio: using OpenAI Whisper API, which costs US$0.06 per 10 minutes of audio, or using Whisper locally.
 # Local transcription is slower and provides worse results, but it is free.
 # If you choose to use the local method, you need to do some things. Refer to the readme.md file for more information.

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -118,11 +118,6 @@ export function checkEnv() {
       }
     });
 
-  if (!process.env.ALLOWED_USERS)
-    console.warn(
-      "ALLOWED_USERS not provided. The bot will work, but will answer to everyone."
-    );
-
   if (process.env.BLOCKED_USERS)
     console.warn(
       "BLOCKED_USERS provided. The bot will ignore messages from these users."


### PR DESCRIPTION
…S warning (#228)